### PR TITLE
feat: underline links in reveal slides

### DIFF
--- a/_extensions/coeos/coeos.scss
+++ b/_extensions/coeos/coeos.scss
@@ -128,3 +128,7 @@ code.sourceCode>span {
   -ms-transform: translateY(-50%), translateX(-50%);
   transform: translateY(-50%), translateX(-50%);
 }
+
+.reveal a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Enhance the visibility of links in reveal slides by adding an underline style, improving user experience and making links more distinguishable.