### PR TITLE
fix: specificity of "panel-tabset-fragments" script

### DIFF
--- a/_extensions/coeos/coeos.html
+++ b/_extensions/coeos/coeos.html
@@ -22,7 +22,7 @@
 # SOFTWARE.
 -->
 
-<script type="text/javascript">
+<script type="text/javascript" id="date-superscript">
   const dateElements = document.querySelectorAll("p.date, div.listing-date");
   dateElements.forEach((el) => {
     el.innerHTML = el.innerHTML.replace(
@@ -31,7 +31,7 @@
     );
   });
 </script>
-<script type="text/javascript">
+<script type="text/javascript" id="menu-logo-visibility">
   Reveal.addEventListener("ready", (event) => {
     if (event.indexh === 0) {
       document.querySelector("div.slide-menu-button").style.display = "none";
@@ -51,11 +51,11 @@
     }
   });
 </script>
-<script type="text/javascript">
+<script type="text/javascript" id="panel-tabset-fragments">
   Reveal.on("ready", function () {
     const tabsetSlides = document.querySelectorAll(".reveal .slides section .panel-tabset");
     tabsetSlides.forEach(function (tabset) {
-      const tabCount = tabset.querySelectorAll("ul li").length;
+      const tabCount = tabset.querySelectorAll("ul.panel-tabset-tabby li").length;
       for (let i = 0; i < tabCount - 1; i++) {
         const fragmentDiv = document.createElement("div");
         fragmentDiv.className = "panel-tabset-fragment fragment";
@@ -70,7 +70,7 @@
     if (event.fragment.classList.contains("panel-tabset-fragment")) {
       const tabIndex = parseInt(event.fragment.dataset.tabIndex);
       const tabset = Reveal.getCurrentSlide().querySelector(".panel-tabset");
-      const tabLinks = tabset.querySelectorAll("ul li a");
+      const tabLinks = tabset.querySelectorAll("ul.panel-tabset-tabby li a");
       if (tabIndex < tabLinks.length) {
         tabLinks[tabIndex].click();
       }
@@ -81,7 +81,7 @@
     if (event.fragment.classList.contains("panel-tabset-fragment")) {
       const tabIndex = parseInt(event.fragment.dataset.tabIndex);
       const tabset = Reveal.getCurrentSlide().querySelector(".panel-tabset");
-      const tabLinks = tabset.querySelectorAll("ul li a");
+      const tabLinks = tabset.querySelectorAll("ul.panel-tabset-tabby li a");
       if (tabIndex > 0) {
         tabLinks[tabIndex - 1].click();
       } else {
@@ -90,7 +90,7 @@
     }
   });
 </script>
-<script type="text/javascript">
+<script type="text/javascript" id="code-annotation-fragments">
   function hideAllTippy() {
     document.querySelectorAll('.code-annotation-anchor').forEach(anchor => {
       const tippyInstance = anchor._tippy;


### PR DESCRIPTION
Enhance the specificity of the "panel-tabset-fragments" script to ensure it correctly targets the intended elements and notthe content such as lists.