### PR TITLE
feat: improve visibility of list item markers in fragment mode

### DIFF
--- a/_extensions/coeos/coeos.scss
+++ b/_extensions/coeos/coeos.scss
@@ -167,3 +167,9 @@ code.sourceCode .code-annotation-anchor .code-annotation-active {
 .reveal li:has(.fragment.visible)::marker {
   color: inherit;
 }
+
+iconify-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}


### PR DESCRIPTION
Update the visibility of list item markers in reveal.js to enhance clarity when fragments are displayed. This change ensures that markers are hidden when only fragments are present and shown when the list item or its fragments are visible.