### PR TITLE
ci: update release workflow to use centralised reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         type: choice
         description: "Version"
         required: false
-        default: "patch"
+        default: "minor"
         options:
           - "patch"
           - "minor"
@@ -29,11 +29,9 @@ permissions:
 
 jobs:
   release:
-    uses: mcanouil/quarto-workflows/.github/workflows/release-extension.yml@main
+    uses: mcanouil/quarto-workflows/.github/workflows/release.yml@main
     secrets: inherit
     with:
       gh-app-id: ${{ vars.APP_ID }}
       version: "${{ github.event.inputs.version }}"
-      formats: "coeos-revealjs"
-      tinytex: false
       quarto: "${{ github.event.inputs.quarto }}"


### PR DESCRIPTION
## Summary

- Update release workflow to use `mcanouil/quarto-workflows/.github/workflows/release.yml@main`.
- Set default version to `minor`.
- Remove extension-specific parameters (`formats`, `tinytex`, etc.).