### PR TITLE
refactor: Target Quarto Wizard v2 extension schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Target the Quarto Wizard v2 extension schema in `_schema.yml`.
+
 ## 1.11.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/coeos/_schema.yml
+++ b/_extensions/coeos/_schema.yml
@@ -1,6 +1,6 @@
 # _schema.yml for "coeos" format extension
 # This extension provides a Reveal.js theme with no user-configurable options.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options: {}


### PR DESCRIPTION
Points `_schema.yml` at the Quarto Wizard v2 meta-schema. v2 uses JSON Schema 2020-12 canonical names exclusively and validates the file strictly, so editor completion and diagnostics match what the extension accepts. The file validates against v2 unchanged.